### PR TITLE
Changes made so that light samples can be auto detected and corrected…

### DIFF
--- a/ECFedgefit.m
+++ b/ECFedgefit.m
@@ -7,6 +7,12 @@ FuncShape = 100; % this is how steep the ecr funciton is and can be changed base
 
 dummy.flat = sum(Im(:,dummy.region(1):dummy.region(2)),dimension).*(-1.5+dimension); % or dummy.flat = sum(Im(:,end-dummy.region:end),2);
 dummy.flat = dummy.flat-min(dummy.flat); %this strange work around is becuase for the grips the sample is light region and for width it is the dark region
+
+%Check if the sample is darker than the background or lighter, assuming
+%that the sample takes up less than half the width of the image
+TopDownFlatten = sum(Im(1:1024,1:1280,1),1)./range(1:1024);[m,c,~,~,~] = linfit(1:1280, TopDownFlatten, ones(1,1280));diff = (((1:1280).*m +c) -TopDownFlatten);
+if (sum(diff<0)>sum(diff>0)) == 0; dummy.flat = dummy.flat.*(-1) + max(dummy.flat) ; end
+
 [~,b] = max(dummy.flat); %take the maximum value as the middle of the image where there will be one edge before and one after
 %find first edge
 dummy.range = 1:b;dummy.step = 1;

--- a/FittedEdges.m
+++ b/FittedEdges.m
@@ -22,6 +22,8 @@ for i = Times
 
     % Look horizontally for sample width
     WidthFine(i,:) = ECFedgefit(dummy.Im,1,1024); %looks at 1:1024
+    
+    %a=1; for j = ceil(GapFine(i,1)):floor(GapFine(i,2)); check.width_profile(a,:) = ECFedgefit(dummy.Im(j,:,1),1,1:1280); a=a+1; end
 
     if rem(max(Times)-i,2000)==0
         fprintf('%d left to complete \n', ((max(Times)-i))) % show progress *I like this to know everything is still running happily

--- a/OutputFigure.m
+++ b/OutputFigure.m
@@ -34,7 +34,7 @@ DebenData.Strain = DebenData.Gap_mm./Deben_info.Sample_height_mm;
 %display result where negative strain is before contact and positive strain
 %is compressive
 figure, plot(1-DebenData.Strain, DebenData.Stress_Pa, 'o')
-title('Example Data from Sample 3 first loading')
+title('Example Data from PTFE 1')
 xlabel('Strain (-)')
 ylabel('Stress (Pa)')
 

--- a/PixelScalingErrFunc.m
+++ b/PixelScalingErrFunc.m
@@ -19,6 +19,9 @@ dummy.middle = round(size(Full_Im,2)./2)-dummy.half_size:round(size(Full_Im,2)./
 check.Sample_width = ECFedgefit(Full_Im,1,dummy.middle);
 check.grip_width = ECFedgefit(Full_Im,1,1:1280);
 
+%for i = 1:10; check.grip_sections(i,:) = ECFedgefit(Full_Im(i*10:(i*10)+10,:,1),1,1:1280); end
+%Grip_width(1) = mean(range(check.grip_sections')); Grip_width(2) = std(range(check.grip_sections'));
+
 sample_width = diff(check.Sample_width); 
 grip_width = diff(check.grip_width);
 Pix2mm = grip_width./30; % assumed that grip is 30 mm across this gives the number of pix in 1 mm


### PR DESCRIPTION
… for

Added lines 10-15 in ECFedgefit.m to flip the data if the sample is lighter than the background rather than previously assumed that the sample would be darker than the background.

Other commented changes are the beginning of  a method to conduct multiple fits on the same edge (in different places) to get an error on the ECF sub-pixel measurement